### PR TITLE
Fix adding UI to top of page

### DIFF
--- a/netflix-ratings-extractor.user.js
+++ b/netflix-ratings-extractor.user.js
@@ -222,13 +222,14 @@
         container.appendChild(gui);
 
         // Add UI to the page.
-        content = document.getElementsByClassName('account-header');
+        content = document.getElementsByClassName('bd');
         if (content && content.length) {
             content = content[0];
             content.insertBefore(container, content.childNodes[0]);
         } else {
+            var refNode = document.querySelectorAll('body > div')[1];
             content = document.body;
-            content.appendChild(container);
+            content.insertBefore(container, refNode);
         }
     }
 


### PR DESCRIPTION
The originally checked `account-header` class seems to have been renamed. In the fallback, the UI is at the end instead. When I scroll down, I catch a glimpse of the Start/Stop area, but I have to keep scrolling down until the list is fully loaded before I can actually click on it. This fixes that and hopefully reduces the need to fix it in the future by always inserting the UI after the first div in the body.

Alternatively, the instructions could be updated.
